### PR TITLE
fix: make production rollback effective

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -180,7 +180,7 @@
             repo: "{{ deploy_repository }}"
             dest: "{{ deploy_root }}"
             version: "{{ deploy_previous_revision.stdout }}"
-            update: false
+            update: true
             force: false
 
         - name: Restore previous docker compose stack

--- a/src/apps/core/tests/test_ansible_deploy_artifacts.py
+++ b/src/apps/core/tests/test_ansible_deploy_artifacts.py
@@ -89,6 +89,10 @@ class TestAnsibleDeployArtifacts(SimpleTestCase):
         self.assertIn("rescue:", self.content)
         self.assertIn("Rollback Git revision", self.content)
         self.assertIn("deploy_previous_revision.stdout", self.content)
+        rollback_task = self.content.split("- name: Rollback Git revision", maxsplit=1)[1].split(
+            "- name: Restore previous docker compose stack", maxsplit=1
+        )[0]
+        self.assertIn("update: true", rollback_task)
 
     def test_deploy_requires_every_compose_service_to_be_running(self) -> None:
         self.assertIn("Check running compose services", self.content)


### PR DESCRIPTION
## Scope
- make the Ansible rescue task actually check out the captured pre-deploy SHA
- add a focused regression assertion for the exact production failure

## Production context
The previous deploy reported a rollback but left the requested release SHA checked out because `update: false` ignores changes to `version`. The ignored production `group_vars` service list has also been synchronized locally with `docker-compose.yml`; that environment-only change is not part of this PR.

## Checks
- `make test` — 292 passed
- focused rollback test — passed after expected RED
- `ansible-playbook ... --syntax-check` — passed
- `docker compose -f docker-compose.yml config --quiet` — passed
- required production services match Compose services

No production deploy is performed by this PR.