### PR TITLE
Document public VPN management rollout

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -83,3 +83,8 @@ Playbook сам запускает миграции через entrypoint Django
 smoke-check и активировать ноду вручную; только затем включить товар и выполнить
 реальную smoke-покупку с импортом subscription URL в HAPP. Эти действия не
 являются разрешением на merge или production deploy.
+
+Для первого MVP rollout `VPNInstance.management_url` указывает на публичный
+plaintext HTTP management proxy ноды. Host firewall отсутствует; bearer token
+и route allowlist остаются. Риск перехвата token/profile payload принят
+пользователем до deploy.

--- a/docs/apps/VPN.md
+++ b/docs/apps/VPN.md
@@ -26,3 +26,8 @@ successful payment только в `POST /api/v1/vpn/payments/buy/` с
 статистики, лимитов устройств/трафика, перевыпуска URL, download-кнопок или
 readiness/error state для пользователя. Недоступность VPN-ноды не откатывает
 успешный платёж и не скрывает subscription URL.
+
+Для первого production rollout management proxy ноды опубликован по публичному
+HTTP без host firewall. Backend продолжает передавать обязательный bearer token,
+а proxy допускает только health и profile management routes. Plaintext exposure
+является явно принятой временной границей MVP.

--- a/docs/features/vpn-mvp/acceptance.md
+++ b/docs/features/vpn-mvp/acceptance.md
@@ -2,7 +2,7 @@
 
 ## Статус
 
-- Scope Contract: `scope_revision: 1`.
+- Scope Contract: `scope_revision: 2`.
 - Product review: `accepted`.
 - Дата автоматизированной приёмки: 31 июля 2026 года.
 - Проверенные implementation heads:
@@ -36,8 +36,8 @@
   backfill неактивной ноды;
 - stateless agent, bounded startup bootstrap, Xray runtime API и локальную
   Hysteria HTTP auth;
-- exact-revision deploy, private path-filtered management proxy, allow-list
-  backend source и недоступность Hysteria `/auth` через management ingress;
+- exact-revision deploy, публичный path-filtered management proxy с bearer
+  auth и недоступность Hysteria `/auth` через management ingress;
 - отсутствие WebSocket и сохранность существующих MTProto-сценариев.
 
 Независимый product review не выявил `blocking_in_scope`,
@@ -49,8 +49,8 @@ AC-001…AC-011 приняты на уровне кода и автоматиз�
 После отдельного разрешения на merge и нового отдельного разрешения на deploy
 нужно выполнить на первой ноде и записать результат:
 
-1. развернуть exact release SHA и проверить bootstrap, private management route
-   и firewall allow-list;
+1. развернуть exact release SHA и проверить bootstrap и публичный management
+   route; plaintext HTTP и отсутствие host firewall приняты как риск MVP;
 2. создать неактивную `VPNInstance`, выполнить повторяемый backfill и проверить
    PUT профиля;
 3. импортировать одну subscription URL в HAPP и подтвердить `2 × N` профилей;

--- a/docs/features/vpn-mvp/acceptance.md
+++ b/docs/features/vpn-mvp/acceptance.md
@@ -4,10 +4,11 @@
 
 - Scope Contract: `scope_revision: 2`.
 - Product review: `accepted`.
-- Дата автоматизированной приёмки: 31 июля 2026 года.
+- Дата автоматизированной приёмки: 1 августа 2026 года.
 - Проверенные implementation heads:
-  - backend и bot: `809203ca555419fa06ff6616f63c8bb234cbf593`;
-  - node-agent: `686772065a1a7d2b1f4cc9d622b4a6593ad77383`.
+  - backend и bot release: `706a445534b868f99610882db319d9c2397b5f44`;
+  - node-agent public-management fix:
+    `3b0cb094833452ff5f897eb86e2849a878b6ca86`.
 - Production deploy и ручные release-проверки не выполнялись.
 
 ## Автоматизированная приёмка

--- a/docs/features/vpn-mvp/architecture.md
+++ b/docs/features/vpn-mvp/architecture.md
@@ -1,10 +1,12 @@
 # VPN MVP — архитектура
 
 - **Статус:** approved
-- **Scope revision:** 1
+- **Scope revision:** 2
 - **Основание:** пользователь утвердил продуктовые требования и обе части
   архитектурного дизайна. Node-agent не хранит постоянную копию профилей;
-  Django остаётся единственным постоянным источником истины.
+  Django остаётся единственным постоянным источником истины. Для первого MVP
+  rollout пользователь отдельно принял риск публичного plaintext HTTP
+  management API без host firewall; bearer token и route allowlist остаются.
 
 ## 1. Принципы MVP
 
@@ -57,9 +59,11 @@ Agent не содержит SQLite, Redis, Celery или иной постоян
 - Xray с одним управляемым VLESS+REALITY inbound;
 - Hysteria 2 с HTTP-аутентификацией через node-agent.
 
-Xray management API, Hysteria auth endpoint и management API agent доступны
-только внутри разрешённого сетевого контура. Публичны только VPN listeners.
-VLESS WebSocket отсутствует.
+Xray management API и Hysteria auth endpoint доступны только внутри Docker
+network ноды. Management proxy agent для первого MVP rollout публикуется по
+публичному IPv4 без TLS и host firewall, но пропускает только health и
+management routes; FastAPI продолжает требовать bearer token. VLESS WebSocket
+отсутствует.
 
 ## 3. Модель данных
 
@@ -275,8 +279,9 @@ backfill нет. Это осознанная операционная грани
 ## 9. Безопасность
 
 - Subscription token, UUID, Hysteria credential и bearer token не логируются.
-- Node-agent management API не выставляется в публичный интернет без сетевого
-  ограничения и TLS.
+- Для первого MVP rollout node-agent management proxy доступен по публичному
+  plaintext HTTP без host firewall. Принят риск перехвата bearer token и
+  profile payload; bearer authentication и proxy route allowlist сохраняются.
 - Xray gRPC API и Hysteria auth endpoint доступны только внутри ноды.
 - REALITY/TLS private keys передаются node runtime через secret files и никогда
   не хранятся в Django или Git.

--- a/docs/features/vpn-mvp/plan.md
+++ b/docs/features/vpn-mvp/plan.md
@@ -6,7 +6,7 @@
 > checkbox (`- [ ]`) syntax for tracking.
 
 - **Status:** approved
-- **Scope revision:** 1
+- **Scope revision:** 2
 
 **Goal:** Добавить в существующий Telegram-бот самостоятельную 30-дневную
 VPN-подписку с VLESS+REALITY и Hysteria 2 на нескольких VPN-нодах и новый
@@ -22,7 +22,10 @@ pytest/unittest, `responses`/`respx`, Docker Compose, Xray, Hysteria 2.
 
 ## Global Constraints
 
-- Scope Contract: только `scope_revision: 1`, BR-001..BR-019 и AC-001..AC-011.
+- Scope Contract: `scope_revision: 2`, BR-001..BR-019 и AC-001..AC-011.
+- Revision 2 меняет только первый production rollout: management proxy
+  публикуется по публичному HTTP без host firewall; bearer token и route
+  allowlist сохраняются. Пользователь явно принял plaintext exposure risk.
 - Реализация production-кода только через TDD: RED → GREEN → REFACTOR.
 - Сервисы backend — `@final` frozen dataclass с `kw_only=True, slots=True,
   frozen=True`; зависимости передаются через поля и module-level factories.
@@ -594,11 +597,13 @@ sections 9–11.
 - pinned Xray and Hysteria image digests;
 - Xray gRPC and Hysteria auth only on internal network;
 - public TCP/443 for VLESS+REALITY and UDP/443 for Hysteria;
-- agent management TLS/network restriction and secret files;
+- public plaintext agent management proxy without host firewall for the first
+  MVP rollout; bearer auth, route allowlist and secret files remain;
 - no credentials or test-server address committed.
 
-- [ ] Написать RED static contract tests на images, ports, private listeners,
-  read-only secrets и отсутствие embedded credentials.
+- [ ] Написать RED static contract tests на images, ports, public management
+  bind, internal-only `/auth`/Xray API, read-only secrets и отсутствие embedded
+  credentials.
 - [ ] Запустить `uv run pytest tests/test_compose_contract.py tests/test_config_contract.py deploy/tests/test_deploy.py`; подтвердить RED до создания runtime/deploy файлов.
 - [ ] Реализовать Compose/config/Ansible/docs с нуля; не открывать production
   listeners и не запускать deploy.


### PR DESCRIPTION
Scope revision: 2

Synchronizes central VPN architecture, deployment, app, plan, and acceptance documentation with the user-approved first MVP rollout: public plaintext HTTP management proxy without host firewall; bearer authentication and route allowlist remain.

No production code or business behavior changes.

Checks:
- Django 366 tests passed
- production Compose config valid
- git diff --check
- independent batch review: approved after acceptance-head correction

Non-goals: TLS, WireGuard, firewall/CIDR allowlist, additional hardening.