### PR TITLE
fix: add emojis to VPN menu buttons

### DIFF
--- a/bot/src/keyboards.py
+++ b/bot/src/keyboards.py
@@ -70,15 +70,16 @@ def vpn_menu() -> InlineKeyboardMarkup:
         inline_keyboard=[
             [
                 InlineKeyboardButton(
-                    text="Купить VPN",
+                    text="💳 Купить VPN",
                     callback_data="vpn",
                     style="success",
                 )
             ],
             [
                 InlineKeyboardButton(
-                    text="Моя подписка",
+                    text="🔑 Моя подписка",
                     callback_data="vpn_subscription",
+                    style="primary",
                 )
             ],
             [_ROOT_BACK],

--- a/bot/tests/test_handlers.py
+++ b/bot/tests/test_handlers.py
@@ -598,8 +598,8 @@ async def test_vpn_product_menu_uses_approved_copy_and_actions():
         ]
         for row in markup.inline_keyboard
     ] == [
-        [("Купить VPN", "vpn", "success")],
-        [("Моя подписка", "vpn_subscription", None)],
+        [("💳 Купить VPN", "vpn", "success")],
+        [("🔑 Моя подписка", "vpn_subscription", "primary")],
         [("🔙 Назад", "show_start_screen", None)],
     ]
 


### PR DESCRIPTION
## Changes

- rename the VPN purchase button to `💳 Купить VPN`;
- rename the subscription button to `🔑 Моя подписка`;
- make the subscription button blue with Telegram `primary` style;
- update the existing keyboard contract test.

## Verification

- bot: 88 passed;
- Django: 367 passed;
- production Compose config: valid;
- diff check: clean.

No backend, database, payment, or deployment changes.