### PR TITLE
fix(payments): parse Crypto Pay accepted assets list

### DIFF
--- a/src/apps/payments/clients/crypto_pay.py
+++ b/src/apps/payments/clients/crypto_pay.py
@@ -119,7 +119,8 @@ class CryptoPayClient:
                 or not isinstance(status, str)
                 or not isinstance(currency_type, str)
                 or not isinstance(fiat, str | None)
-                or not isinstance(accepted_assets, str)
+                or not isinstance(accepted_assets, list)
+                or not all(isinstance(asset, str) for asset in accepted_assets)
                 or not isinstance(paid_asset, str | None)
                 or not isinstance(payload, str)
                 or not isinstance(bot_invoice_url, str)
@@ -131,7 +132,7 @@ class CryptoPayClient:
                 currency_type=currency_type,
                 fiat=fiat,
                 amount=amount,
-                accepted_assets=frozenset(accepted_assets.split(",")),
+                accepted_assets=frozenset(accepted_assets),
                 paid_asset=paid_asset,
                 payload=payload,
                 bot_invoice_url=bot_invoice_url,

--- a/src/apps/payments/tests/test_crypto_pay_client.py
+++ b/src/apps/payments/tests/test_crypto_pay_client.py
@@ -20,7 +20,7 @@ VALID_INVOICE_JSON = {
     "currency_type": "fiat",
     "fiat": "RUB",
     "amount": "99.00",
-    "accepted_assets": "USDT,TON",
+    "accepted_assets": ["USDT", "TON"],
     "paid_asset": "USDT",
     "payload": "0f57a4f1-1956-45be-8dc0-d891c00c74c1",
     "bot_invoice_url": "https://t.me/CryptoBot?start=test",
@@ -209,6 +209,25 @@ class TestCryptoPayClient(SimpleTestCase):
             with self.subTest(field=field):
                 invoice = deepcopy(VALID_INVOICE_JSON)
                 invoice[field] = value
+                responses.reset()
+                responses.post(
+                    "https://testnet-pay.crypt.bot/api/createInvoice",
+                    json={"ok": True, "result": invoice},
+                )
+
+                with self.assertRaisesRegex(CryptoPayClientError, "^cryptopay_malformed$"):
+                    self.client.create_invoice(
+                        amount=Decimal("99.00"),
+                        payload="0f57a4f1-1956-45be-8dc0-d891c00c74c1",
+                        description="MTProto на 30 дней",
+                    )
+
+    @responses.activate
+    def test_malformed_accepted_assets_raise_safe_error(self) -> None:
+        for accepted_assets in ("USDT,TON", ["USDT", 731]):
+            with self.subTest(accepted_assets=accepted_assets):
+                invoice = deepcopy(VALID_INVOICE_JSON)
+                invoice["accepted_assets"] = accepted_assets
                 responses.reset()
                 responses.post(
                     "https://testnet-pay.crypt.bot/api/createInvoice",


### PR DESCRIPTION
## Scope Contract

- scope_revision: 1
- Goal: restore Crypto Pay invoice creation when the provider returns accepted_assets as JSON list[str].
- AC: valid list[str] maps to frozenset; legacy string and mixed-type list return safe cryptopay_malformed.
- Non-goals: legacy string compatibility, models/migrations, API/webhook/fulfillment/bot changes, UX changes, production deploy.

## Root cause

Production Crypto Pay returned accepted_assets as ["USDT", "TON"], while the boundary parser required a comma-separated string and rejected a valid invoice response.

## Changes

- Parse and strictly validate accepted_assets as list[str].
- Normalize the provider value to the existing frozenset DTO field.
- Update the provider-shaped fixture and add malformed-input regression coverage.

## Verification

- TDD RED: live-shaped list response failed with cryptopay_malformed before the fix.
- Crypto Pay client: 12/12.
- Payments suite: 132/132.
- Full make test: 464/464.
- docker compose -f docker-compose.yml config --quiet: pass.
- git diff --check: pass.
- Independent batch review: VERDICT approved.

## Deploy impact

No migrations or env changes. Merge and production deploy require separate explicit approvals.