### PR TITLE
fix(payments): accept Crypto Pay expiry drift

### DIFF
--- a/src/apps/payments/services/create_crypto_invoice.py
+++ b/src/apps/payments/services/create_crypto_invoice.py
@@ -120,8 +120,6 @@ def _created_invoice_error_code(
         return "create_timestamp_invalid"
     if invoice.expiration_date <= invoice.created_at:
         return "create_expiration_invalid"
-    if invoice.expiration_date - invoice.created_at != timedelta(seconds=1800):
-        return "create_expiration_invalid"
     return None
 
 

--- a/src/apps/payments/tests/test_create_crypto_invoice_service.py
+++ b/src/apps/payments/tests/test_create_crypto_invoice_service.py
@@ -259,6 +259,27 @@ class TestCreateOrReuseCryptoInvoiceService(TestCase):
             ),
         )
 
+    def test_provider_subsecond_expiration_drift_is_accepted(self) -> None:
+        ProductFactory(code=ProductCodeEnum.MTPROTO_30D, price=Decimal("9900"))
+        provider_expiration = self.now + timedelta(seconds=1799, milliseconds=998)
+
+        def create_invoice(
+            *, amount: Decimal, payload: str, description: str
+        ) -> CryptoInvoiceDTO:
+            return replace(
+                self._valid_invoice(amount=amount, payload=payload),
+                expiration_date=provider_expiration,
+            )
+
+        self.client.create_invoice.side_effect = create_invoice
+
+        result = self.service(request=self._request())
+
+        intent = CryptoPaymentIntent.objects.get()
+        self.assertEqual(intent.status, CryptoPaymentIntentStatusEnum.ACTIVE)
+        self.assertEqual(intent.provider_expires_at, provider_expiration)
+        self.assertEqual(result.expires_at, provider_expiration)
+
     def test_stale_lease_loss_does_not_return_non_active_intent(self) -> None:
         ProductFactory(code=ProductCodeEnum.MTPROTO_30D, price=Decimal("9900"))
 
@@ -303,10 +324,6 @@ class TestCreateOrReuseCryptoInvoiceService(TestCase):
             ("create_timestamp_invalid", {"created_at": naive}),
             ("create_timestamp_invalid", {"expiration_date": naive}),
             ("create_expiration_invalid", {"expiration_date": self.now}),
-            (
-                "create_expiration_invalid",
-                {"expiration_date": self.now + timedelta(seconds=1799)},
-            ),
         )
         for reason_code, changes in cases:
             with self.subTest(reason_code=reason_code, changes=changes):


### PR DESCRIPTION
## Scope Contract

- scope_revision: 2
- packet: HOTFIX-002
- Goal: accept valid Crypto Pay invoices when provider timestamps have subsecond generation drift.
- AC: positive timezone-aware provider expiry activates and is stored exactly; equal/reversed expiry remains rejected.
- Non-goals: tolerance constants, other validators, client/parser, models/migrations, API/webhook/reconciliation/bot/env, concurrency-flake changes.

## Root cause

The backend sent expires_in=1800 but additionally required expiration_date-created_at to equal exactly 1800.000 seconds. Live Crypto Pay responses were 1799.998-1799.999 seconds because the timestamps are generated separately, so valid invoices were rejected as create_expiration_invalid.

## Changes

- Remove only the redundant exact-duration comparison.
- Keep timezone awareness and expiration_date > created_at validation.
- Add a production-shaped regression test proving 1799.998 seconds activates and preserves the exact provider expiry.

## Verification

- TDD RED: production-shaped response raised CryptoInvoiceUnavailable before the fix.
- Service suite: 14/14.
- Payments suite: 133/133.
- Full make test: 465/465.
- Compose config and git diff check: pass.
- Independent batch review: VERDICT approved.

## Risk and deploy impact

Request still sends expires_in=1800 and all identity, amount, currency, asset, status, unpaid and HTTPS URL checks remain strict. No migrations or env changes. A known unrelated SQLite concurrency test can intermittently raise creation_lost and was not changed. Merge and production deploy require separate approvals.