### PR TITLE
fix(payments): parse Crypto Pay webhook asset list

### DIFF
--- a/src/apps/payments/api/v1/serializers/crypto_pay_serializers.py
+++ b/src/apps/payments/api/v1/serializers/crypto_pay_serializers.py
@@ -25,10 +25,15 @@ class CreateCryptoInvoiceResponseSerializer(serializers.Serializer):
     reused = serializers.BooleanField()
 
 
-class _AcceptedAssetsField(serializers.CharField):
+class _AcceptedAssetsField(serializers.Field):
+    default_error_messages = {"invalid": "Expected a list of strings."}
+
     def to_internal_value(self, data: object) -> frozenset[str]:
-        value = super().to_internal_value(data)
-        return frozenset(value.split(","))
+        if not isinstance(data, list) or not all(
+            isinstance(asset, str) for asset in data
+        ):
+            self.fail("invalid")
+        return frozenset(data)
 
 
 class CryptoWebhookInvoiceSerializer(serializers.Serializer):

--- a/src/apps/payments/tests/test_views/test_crypto_webhook_view.py
+++ b/src/apps/payments/tests/test_views/test_crypto_webhook_view.py
@@ -65,7 +65,7 @@ class TestCryptoPayWebhookView(APITestCase):
                 "currency_type": "fiat",
                 "fiat": "RUB",
                 "amount": "99.00",
-                "accepted_assets": "USDT,TON",
+                "accepted_assets": ["USDT", "TON"],
                 "paid_asset": "USDT",
                 "payload": "0f57a4f1-1956-45be-8dc0-d891c00c74c1",
                 "bot_invoice_url": "https://t.me/CryptoBot?start=private",
@@ -153,6 +153,17 @@ class TestCryptoPayWebhookView(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assert_no_processing()
 
+    def test_malformed_accepted_assets_are_400_without_processing(self) -> None:
+        for accepted_assets in ("USDT,TON", ["USDT", 731]):
+            with self.subTest(accepted_assets=accepted_assets):
+                event = self.event()
+                event["payload"]["accepted_assets"] = accepted_assets
+
+                response = self.post_event(event)
+
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assert_no_processing()
+
     def test_each_signed_warning_logs_and_enqueues_only_safe_fields(self) -> None:
         cases = (
             ("invoice_id", 999999, "unknown_invoice", None),
@@ -163,7 +174,7 @@ class TestCryptoPayWebhookView(APITestCase):
             ("amount", "98.99", "amount_mismatch", self.intent.pk),
             (
                 "accepted_assets",
-                "USDT",
+                ["USDT"],
                 "accepted_assets_mismatch",
                 self.intent.pk,
             ),


### PR DESCRIPTION
## Scope Contract

- scope_revision: 3
- packet: HOTFIX-003
- Goal: process real signed Crypto Pay invoice_paid webhooks immediately when accepted_assets is JSON list[str].
- AC: list[str] normalizes to frozenset and valid/duplicate events return 200; legacy string and mixed list return 400 before processing; subset list reaches existing semantic warning.
- Non-goals: other provider fields or validators, client, models/migrations, reconciliation, bot, env, logging, deploy.

## Root cause

Crypto Pay delivered the paid webhook immediately and retried after 400 responses, but the webhook serializer expected accepted_assets as a comma-separated string. The live paid Invoice uses a JSON list, so validation failed only at payload.accepted_assets. Reconciliation fulfilled the payment 162 seconds later.

## Changes

- Strictly parse webhook accepted_assets as list[str] and normalize to the existing frozenset DTO field.
- Update the signed webhook fixture to the production shape.
- Add malformed legacy-string and mixed-list regression coverage.

## Verification

- TDD RED: valid signed webhook returned 400 instead of 200 before the fix.
- Webhook suite: 9/9.
- Payments suite: 134/134.
- Full make test: 466/466.
- Compose config and diff check: pass.
- Independent batch review: VERDICT approved.

## Risk and deploy impact

HMAC/raw-body gates and all semantic/financial checks are unchanged. Request-side createInvoice still sends accepted_assets=USDT,TON. No migrations or env changes. Merge and production deploy require separate approvals.