### PR TITLE
fix(payments): accept Platega invoice response

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,11 @@ telemt (MTProto-прокси)
 
 **VDS Instance** — FastAPI-сервис на каждом VDS-сервере. Принимает команды от Django и управляет прокси-сервером telemt.
 
+`RequestLoggingMiddleware` для mutating API-запросов сохраняет только HTTP
+method и безопасный path. Headers и body не логируются; секреты в URL Crypto
+webhook маскируются, а публичный Platega callback полностью обходит middleware
+logging до чтения body.
+
 ## Стек
 
 | Компонент | Технология |
@@ -110,7 +115,8 @@ username (либо Telegram ID как fallback).
 
 Успешным считается только HTTP `200` с UUID transaction ID, `PENDING`, usable
 HTTPS redirect и `expiresIn=00:15:00`. Необязательные provider echoes при
-наличии сверяются с `SBPQR`, суммой/RUB, `BOT_LINK` и merchant ID. Ошибки
+наличии сверяются с `SBPQR`, `BOT_LINK` и merchant ID; provider-controlled
+`paymentDetails` в ответе не используется для валидации. Ошибки
 наружу несут только reason code `timeout`, `unavailable`, `malformed` или
 `create_mismatch`; request/response body, URL, metadata и credentials не
 логируются. HTTP GET, polling и bot credentials для Platega отсутствуют.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -288,10 +288,11 @@ ID if a saved username is absent.
 
 A usable creation response is exactly HTTP `200` with a JSON object containing
 UUID `transactionId`, `status: "PENDING"`, HTTPS `redirect`, and
-`expiresIn: "00:15:00"`. Optional `paymentMethod: "SBPQR"`, `paymentDetails`,
-`return`, and `merchantId` are accepted only when they match the request. Client
-errors expose only `timeout`, `unavailable`, `malformed`, or `create_mismatch`;
-credentials, metadata, bodies and payment URLs are not logged.
+`expiresIn: "00:15:00"`. Optional `paymentMethod: "SBPQR"`, `return`, and
+`merchantId` are accepted only when they match the request. Provider-controlled
+`paymentDetails` is ignored because Platega may return it as either a string or
+an object. Client errors expose only `timeout`, `unavailable`, `malformed`, or
+`create_mismatch`; credentials, metadata, bodies and payment URLs are not logged.
 
 ### POST /api/v1/payments/platega/callback/
 

--- a/src/apps/core/tests/test_crypto_webhook_logging.py
+++ b/src/apps/core/tests/test_crypto_webhook_logging.py
@@ -59,18 +59,24 @@ class TestCryptoWebhookLogging(APITestCase):
         self.assertNotIn("path-secret", "\n".join(request_logs.output))
         self.assertIn("[REDACTED]", "\n".join(request_logs.output))
 
-    def test_non_webhook_post_keeps_headers_and_decoded_body(self) -> None:
+    def test_non_webhook_post_omits_headers_and_body(self) -> None:
         with self.assertLogs("config.middlewares", level="INFO") as captured:
             self.client.generic(
                 "POST",
                 "/ordinary-path/",
-                b'{"visible":"ordinary-body"}',
+                b'{"username":"private-telegram-id"}',
                 content_type="application/json",
-                HTTP_X_REQUEST_CONTEXT="ordinary-header",
+                HTTP_BOT_AUTH_TOKEN="private-bot-token",
             )
 
         logged = captured.records[0].msg
-        self.assertEqual(logged["method"], "POST")
-        self.assertEqual(logged["path"], "/ordinary-path/")
-        self.assertEqual(logged["body"], {"visible": "ordinary-body"})
-        self.assertEqual(logged["headers"]["X-Request-Context"], "ordinary-header")
+        self.assertEqual(
+            logged,
+            {
+                "method": "POST",
+                "path": "/ordinary-path/",
+            },
+        )
+        rendered = "\n".join(captured.output)
+        self.assertNotIn("private-telegram-id", rendered)
+        self.assertNotIn("private-bot-token", rendered)

--- a/src/apps/payments/clients/platega.py
+++ b/src/apps/payments/clients/platega.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import timedelta
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from math import isfinite
 from typing import final
 from urllib.parse import urlsplit
@@ -73,7 +73,6 @@ class PlategaClient:
             raise PlategaClientError(response_error)
         transaction, validation_error = self._to_transaction(
             payload=payload,
-            amount=amount,
             return_url=return_url,
         )
         if validation_error is not None:
@@ -85,7 +84,6 @@ class PlategaClient:
         self,
         *,
         payload: object,
-        amount: Decimal,
         return_url: str,
     ) -> tuple[PlategaTransactionDTO | None, str | None]:
         try:
@@ -103,7 +101,6 @@ class PlategaClient:
                 raise TypeError
             echo_error = _validate_optional_echoes(
                 payload=payload,
-                amount=amount,
                 return_url=return_url,
                 merchant_id=self.merchant_id,
             )
@@ -115,7 +112,7 @@ class PlategaClient:
                 redirect_url=redirect_url,
                 expires_in=expires_in,
             ), None
-        except (AttributeError, InvalidOperation, KeyError, TypeError, ValueError):
+        except (AttributeError, KeyError, TypeError, ValueError):
             return None, "malformed"
 
 
@@ -153,7 +150,6 @@ def _serialize_create_transaction_body(
 def _validate_optional_echoes(
     *,
     payload: dict[str, object],
-    amount: Decimal,
     return_url: str,
     merchant_id: str,
 ) -> str | None:
@@ -163,22 +159,6 @@ def _validate_optional_echoes(
         return "create_mismatch"
     if "merchantId" in payload and payload["merchantId"] != merchant_id:
         return "create_mismatch"
-    if "paymentDetails" in payload:
-        payment_details = payload["paymentDetails"]
-        if isinstance(payment_details, str):
-            try:
-                payment_details = json.loads(payment_details)
-            except ValueError:
-                return "malformed"
-        if not isinstance(payment_details, dict):
-            return "malformed"
-        try:
-            echoed_amount = Decimal(str(payment_details["amount"]))
-            echoed_currency = payment_details["currency"]
-        except (InvalidOperation, KeyError, TypeError, ValueError):
-            return "malformed"
-        if echoed_amount != amount or echoed_currency != "RUB":
-            return "create_mismatch"
     return None
 
 

--- a/src/apps/payments/tests/test_platega_client.py
+++ b/src/apps/payments/tests/test_platega_client.py
@@ -92,10 +92,11 @@ class TestPlategaClient(SimpleTestCase):
         self.assertEqual(json.loads(body)["metadata"], {"userId": "123456789", "userName": "123456789"})
 
     @responses.activate
-    def test_accepts_matching_optional_echoes_in_object_or_json_string_form(self) -> None:
+    def test_ignores_optional_payment_details_provider_echo(self) -> None:
         for payment_details in (
             {"amount": "99.00", "currency": "RUB"},
-            '{"amount": 99.00, "currency": "RUB"}',
+            "99 RUB",
+            {"unexpected": "provider-controlled"},
         ):
             with self.subTest(payment_details=payment_details):
                 payload = deepcopy(VALID_TRANSACTION_JSON)
@@ -122,8 +123,6 @@ class TestPlategaClient(SimpleTestCase):
             ("paymentMethod", "CARD", "create_mismatch"),
             ("merchantId", "other-merchant", "create_mismatch"),
             ("return", "https://example.test", "create_mismatch"),
-            ("paymentDetails", {"amount": "98.00", "currency": "RUB"}, "create_mismatch"),
-            ("paymentDetails", {"amount": "99.00", "currency": "USD"}, "create_mismatch"),
         )
         for field, value, code in cases:
             with self.subTest(field=field, value=value):

--- a/src/config/middlewares.py
+++ b/src/config/middlewares.py
@@ -1,6 +1,4 @@
-import json
 import logging
-from json import JSONDecodeError
 from re import compile
 
 logger = logging.getLogger(__name__)
@@ -12,13 +10,6 @@ _REDACTED_CRYPTO_WEBHOOK_PATH = "/api/v1/payments/crypto/webhooks/[REDACTED]/"
 _PLATEGA_CALLBACK_PATH = "/api/v1/payments/platega/callback/"
 
 
-def _decode_body(raw_body: bytes) -> object:
-    try:
-        return json.loads(raw_body)
-    except (JSONDecodeError, UnicodeDecodeError):
-        return raw_body.decode("utf-8", errors="replace")
-
-
 def _safe_request_log(request) -> dict[str, object]:
     if _CRYPTO_WEBHOOK_PATH.fullmatch(request.path):
         return {
@@ -28,8 +19,6 @@ def _safe_request_log(request) -> dict[str, object]:
     return {
         "method": request.method,
         "path": request.path,
-        "headers": dict(request.headers),
-        "body": _decode_body(request.body),
     }
 
 


### PR DESCRIPTION
## Review Brief

### Goal

Restore Platega SBP invoice creation for the provider's documented successful response and prevent credentials or Telegram identity from entering ordinary request logs.

### Observable behavior

- Platega create responses may contain `paymentDetails` in any provider-controlled representation; backend ignores that echo while retaining validation of transaction ID, status, redirect, expiry, method, return URL, and merchant ID.
- Mutating request middleware logs only HTTP method and a safe path. It never logs request headers or body.
- Existing Crypto webhook path redaction and Platega callback/admin logging bypasses remain unchanged.

### Non-goals

- No retries, polling, provider status GET, lifecycle changes, migrations, dependencies, bot changes, credentials, products, prices, callback, fulfilment, or notification changes.
- The `platega_sbp` payment method is not enabled by this PR.

### Acceptance criteria

- A documented response containing `paymentDetails: "99 RUB"` produces a valid local invoice result.
- Required Platega response validation and supported optional echo checks remain fail-closed.
- Request logs contain no `Bot-Auth-Token`, Telegram identity, headers, or body.
- Existing webhook/path privacy boundaries and canonical documentation remain consistent.

### Verification

- Platega client: 7/7 passed.
- Request logging and Platega callback: 5/5 passed.
- Combined focused regression: 12/12 passed.
- Full backend suite: 572/572 passed.
- `makemigrations --check --dry-run`: no changes detected.
- Production Compose config and `git diff --check`: passed.
- Independent batch review of exact commit: approved, no findings.

### Risks and deploy impact

- `paymentDetails` is intentionally not used as a response integrity signal; the request amount remains backend-owned and callback fulfilment still requires the stored amount/currency/method identity.
- Request logs become less detailed by design, retaining only method/path.
- Whole-stack deploy is required after merge; no migration or environment changes. Keep `platega_sbp` disabled until post-deploy smoke verification.
