### PR TITLE
fix(payments): accept minimal Platega response

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,10 +113,10 @@ method `2`, `RUB` decimal amount с двумя знаками без float, об
 `BOT_LINK`, случайный local UUID payload и antifraud metadata с Telegram ID и
 username (либо Telegram ID как fallback).
 
-Успешным считается только HTTP `200` с UUID transaction ID, `PENDING`, usable
-HTTPS redirect и `expiresIn=00:15:00`. Необязательные provider echoes при
-наличии сверяются с `SBPQR`, `BOT_LINK` и merchant ID; provider-controlled
-`paymentDetails` в ответе не используется для валидации. Ошибки
+Успешным считается только HTTP `200` с UUID transaction ID, `PENDING` и usable
+HTTPS redirect. Provider-controlled echoes, включая `expiresIn`, `return`,
+`paymentMethod`, `merchantId` и `paymentDetails`, не используются для
+валидации; локальный intent получает фиксированный TTL 15 минут. Ошибки
 наружу несут только reason code `timeout`, `unavailable`, `malformed` или
 `create_mismatch`; request/response body, URL, metadata и credentials не
 логируются. HTTP GET, polling и bot credentials для Platega отсутствуют.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -287,12 +287,12 @@ RUB amount serialized directly from `Decimal`, the product description, both
 ID if a saved username is absent.
 
 A usable creation response is exactly HTTP `200` with a JSON object containing
-UUID `transactionId`, `status: "PENDING"`, HTTPS `redirect`, and
-`expiresIn: "00:15:00"`. Optional `paymentMethod: "SBPQR"`, `return`, and
-`merchantId` are accepted only when they match the request. Provider-controlled
-`paymentDetails` is ignored because Platega may return it as either a string or
-an object. Client errors expose only `timeout`, `unavailable`, `malformed`, or
-`create_mismatch`; credentials, metadata, bodies and payment URLs are not logged.
+UUID `transactionId`, `status: "PENDING"`, and HTTPS `redirect`. All
+provider-controlled response echoes, including `expiresIn`, `paymentMethod`,
+`paymentDetails`, `return`, and `merchantId`, are ignored; backend assigns a
+fixed local expiry of 15 minutes. Client errors expose only `timeout`,
+`unavailable`, `malformed`, or `create_mismatch`; credentials, metadata, bodies
+and payment URLs are not logged.
 
 ### POST /api/v1/payments/platega/callback/
 

--- a/src/apps/payments/clients/platega.py
+++ b/src/apps/payments/clients/platega.py
@@ -73,7 +73,6 @@ class PlategaClient:
             raise PlategaClientError(response_error)
         transaction, validation_error = self._to_transaction(
             payload=payload,
-            return_url=return_url,
         )
         if validation_error is not None:
             raise PlategaClientError(validation_error)
@@ -84,7 +83,6 @@ class PlategaClient:
         self,
         *,
         payload: object,
-        return_url: str,
     ) -> tuple[PlategaTransactionDTO | None, str | None]:
         try:
             if not isinstance(payload, dict):
@@ -92,25 +90,15 @@ class PlategaClient:
             transaction_id = UUID(payload["transactionId"])
             status = payload["status"]
             redirect_url = payload["redirect"]
-            expires_in = _parse_expires_in(payload["expiresIn"])
-            if expires_in is None:
-                raise TypeError
             if not isinstance(status, str) or status != "PENDING":
                 return None, "create_mismatch"
             if not isinstance(redirect_url, str) or not _is_usable_https_url(redirect_url):
                 raise TypeError
-            echo_error = _validate_optional_echoes(
-                payload=payload,
-                return_url=return_url,
-                merchant_id=self.merchant_id,
-            )
-            if echo_error is not None:
-                return None, echo_error
             return PlategaTransactionDTO(
                 transaction_id=transaction_id,
                 status=status,
                 redirect_url=redirect_url,
-                expires_in=expires_in,
+                expires_in=timedelta(minutes=15),
             ), None
         except (AttributeError, KeyError, TypeError, ValueError):
             return None, "malformed"
@@ -147,32 +135,11 @@ def _serialize_create_transaction_body(
     )
 
 
-def _validate_optional_echoes(
-    *,
-    payload: dict[str, object],
-    return_url: str,
-    merchant_id: str,
-) -> str | None:
-    if "paymentMethod" in payload and payload["paymentMethod"] != "SBPQR":
-        return "create_mismatch"
-    if "return" in payload and payload["return"] != return_url:
-        return "create_mismatch"
-    if "merchantId" in payload and payload["merchantId"] != merchant_id:
-        return "create_mismatch"
-    return None
-
-
 def _read_response_json(*, response: requests.Response) -> tuple[object | None, str | None]:
     try:
         return response.json(), None
     except ValueError:
         return None, "malformed"
-
-
-def _parse_expires_in(value: object) -> timedelta | None:
-    if value != "00:15:00":
-        return None
-    return timedelta(minutes=15)
 
 
 def _is_usable_https_url(value: str) -> bool:

--- a/src/apps/payments/tests/test_platega_client.py
+++ b/src/apps/payments/tests/test_platega_client.py
@@ -92,26 +92,24 @@ class TestPlategaClient(SimpleTestCase):
         self.assertEqual(json.loads(body)["metadata"], {"userId": "123456789", "userName": "123456789"})
 
     @responses.activate
-    def test_ignores_optional_payment_details_provider_echo(self) -> None:
-        for payment_details in (
-            {"amount": "99.00", "currency": "RUB"},
-            "99 RUB",
-            {"unexpected": "provider-controlled"},
-        ):
-            with self.subTest(payment_details=payment_details):
-                payload = deepcopy(VALID_TRANSACTION_JSON)
-                payload.update(
-                    {
-                        "paymentMethod": "SBPQR",
-                        "paymentDetails": payment_details,
-                        "return": BOT_LINK,
-                        "merchantId": "merchant-id",
-                    }
-                )
-                responses.reset()
-                responses.post(ENDPOINT, json=payload, status=200)
+    def test_ignores_provider_echoes_and_uses_fixed_local_expiry(self) -> None:
+        payload = deepcopy(VALID_TRANSACTION_JSON)
+        payload.update(
+            {
+                "expiresIn": None,
+                "paymentMethod": "provider-controlled",
+                "paymentDetails": "99 RUB",
+                "return": "https://provider.example/normalized-return",
+                "merchantId": "provider-controlled",
+                "extra": {"provider": "controlled"},
+            }
+        )
+        responses.post(ENDPOINT, json=payload, status=200)
 
-                self.assertEqual(self._create_transaction().transaction_id, UUID(TRANSACTION_ID))
+        result = self._create_transaction()
+
+        self.assertEqual(result.transaction_id, UUID(TRANSACTION_ID))
+        self.assertEqual(result.expires_in.total_seconds(), 900)
 
     @responses.activate
     def test_rejects_mismatch_or_unusable_creation_response_with_safe_code(self) -> None:
@@ -119,10 +117,6 @@ class TestPlategaClient(SimpleTestCase):
             ("status", "CONFIRMED", "create_mismatch"),
             ("transactionId", "not-a-uuid", "malformed"),
             ("redirect", "http://pay.platega.example/redirect", "malformed"),
-            ("expiresIn", "00:14:59", "malformed"),
-            ("paymentMethod", "CARD", "create_mismatch"),
-            ("merchantId", "other-merchant", "create_mismatch"),
-            ("return", "https://example.test", "create_mismatch"),
         )
         for field, value, code in cases:
             with self.subTest(field=field, value=value):


### PR DESCRIPTION
## Review Brief

### Goal

Accept the real Platega SBP create response using only the fields required to hand a valid payment link to the user.

### Observable behavior

- A Platega HTTP 200 response is accepted when it contains a UUID transaction ID, exact `PENDING` status, and a usable HTTPS redirect.
- All provider-controlled response echoes are ignored, including `expiresIn`, `paymentDetails`, `paymentMethod`, `return`, and `merchantId`.
- Every accepted create response receives a fixed local expiry of 15 minutes.

### Non-goals

- No retries, polling, provider status GET, states, migrations, dependencies, callback, fulfilment, notifications, bot, products, prices, environment, or logging changes.
- No provider response content is logged or persisted.
- The `platega_sbp` payment method is not enabled.

### Acceptance criteria

- The observed provider shape with `expiresIn: null`, string `paymentDetails`, changed `return`, and extra echoes produces a valid invoice DTO.
- Invalid JSON, missing/invalid transaction ID, non-PENDING status, and unusable redirect remain safely rejected.
- Canonical architecture and API contract documentation match the implementation.

### Verification

- RED: observed provider response fixture failed with `malformed` before implementation.
- Platega client: 7/7 passed.
- Focused create/service/concurrency/API regression: 24/24 passed.
- Full backend suite: 572/572 passed.
- `makemigrations --check --dry-run`: no changes detected.
- Production Compose config and `git diff --check`: passed.
- Independent batch review of exact commit: approved, no findings.

### Risks and deploy impact

- Provider echoes are intentionally not integrity signals; callback fulfilment still validates the stored transaction identity, amount, currency, and payment method.
- Whole-stack deploy is required after merge; no migration or environment changes.
- Production currently runs the previous release with `platega_sbp` disabled; keep it disabled until a real post-deploy create smoke succeeds.
