### PR TITLE
fix(payments): accept Platega callback payload

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -132,8 +132,9 @@ client наружу несут только reason code `timeout`, `unavailable`
 До чтения body/request data Django извлекает raw `X-MerchantId` и `X-Secret` и
 всегда вычисляет две отдельные constant-time проверки; пустая backend
 конфигурация fail-closed. Только после этого exact-key serializer принимает
-`id`, `amount`, `currency`, `status`, `paymentMethod`, а validation service
-сопоставляет normalized DTO с сохранённым intent. Callback-only JSON parser
+обязательные `id`, `amount`, `currency`, `status`, `paymentMethod` и игнорирует
+необязательный provider echo `payload`, а validation service сопоставляет
+normalized DTO с сохранённым intent. Callback-only JSON parser
 разбирает integer, fraction и exponent tokens сразу в Decimal без binary float;
 serializer принимает только конечное JSON-число произвольной точности и
 отклоняет строки, boolean, `NaN` и бесконечности. Validator без округления

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -310,7 +310,8 @@ permissions. До чтения JSON backend извлекает raw headers `X-Me
 затем объединяет результаты. Пустые configured credentials fail-closed.
 Missing/invalid header возвращает пустой `401` без body parsing.
 
-После успешной аутентификации принимается JSON-объект с ровно пятью ключами:
+После успешной аутентификации принимается JSON-объект с пятью обязательными
+ключами и необязательным provider echo `payload`:
 
 ```json
 {
@@ -318,9 +319,14 @@ Missing/invalid header возвращает пустой `401` без body parsi
   "amount": 99.0036,
   "currency": "RUB",
   "status": "CONFIRMED",
-  "paymentMethod": 2
+  "paymentMethod": 2,
+  "payload": "492a37cf-49cf-43ac-a693-dbc942ac98e2"
 }
 ```
+
+`payload` не участвует в выборе intent или валидации и не передаётся в доменный
+DTO; callback без него остаётся валидным. Другие дополнительные ключи
+отклоняются до domain processing.
 
 `amount` должен быть конечным JSON-числом. Integer, fraction и finite exponent
 принимаются без продуктового ограничения на число целых или дробных знаков и
@@ -331,7 +337,7 @@ boolean, `null`, container, `NaN` и бесконечность недопуст
 `98.999999999999999999` остаётся mismatch. Проверки transaction ID, точных
 `RUB`, method `2`, статуса и состояния intent сохраняются.
 
-Authenticated malformed JSON, missing/extra/malformed fields, unknown
+Authenticated malformed JSON, missing/unrecognized extra/malformed fields, unknown
 transaction, mismatch, unsupported status, normal/repeated `CANCELED` и
 duplicate fulfillment возвращают пустой `200` без небезопасной выдачи.
 `CHARGEBACKED` относится только к unsupported safe acknowledgement и не

--- a/docs/apps/PAYMENTS.md
+++ b/docs/apps/PAYMENTS.md
@@ -124,8 +124,9 @@ invoice, successful-payment routing и fulfilment действующих Stars/C
 authentication/permission lists. До request data/body parsing он выполняет обе
 отдельные constant-time проверки raw `X-MerchantId` и `X-Secret`; пустые
 configured credentials и missing/invalid headers дают `401`. Только
-authenticated exact-key payload преобразуется в `PlategaCallbackDTO` и
-передаётся validator/apply factories. Callback-only JSON parser разбирает
+authenticated payload с пятью обязательными provider-полями и необязательным
+игнорируемым echo `payload` преобразуется в `PlategaCallbackDTO` и передаётся
+validator/apply factories. Callback-only JSON parser разбирает
 integer, fraction и finite exponent tokens напрямую в Decimal. Amount принимает
 только конечное JSON-число произвольной точности; numeric strings, boolean,
 `null`, containers, `NaN` и бесконечности отклоняются без domain processing.

--- a/src/apps/payments/api/v1/serializers/platega_serializers.py
+++ b/src/apps/payments/api/v1/serializers/platega_serializers.py
@@ -55,7 +55,8 @@ class PlategaCallbackSerializer(serializers.Serializer):
     paymentMethod = serializers.IntegerField(source="payment_method")
 
     def to_internal_value(self, data: object) -> dict[str, object]:
-        expected_keys = {"id", "amount", "currency", "status", "paymentMethod"}
-        if not isinstance(data, Mapping) or set(data) != expected_keys:
+        required_keys = {"id", "amount", "currency", "status", "paymentMethod"}
+        allowed_key_sets = (required_keys, required_keys | {"payload"})
+        if not isinstance(data, Mapping) or set(data) not in allowed_key_sets:
             raise serializers.ValidationError("Expected exact callback fields.")
         return super().to_internal_value(data)

--- a/src/apps/payments/tests/test_views/test_platega_callback_view.py
+++ b/src/apps/payments/tests/test_views/test_platega_callback_view.py
@@ -484,6 +484,18 @@ class TestPlategaCallbackView(APITestCase):
         self.assertEqual(callback.payment_method, 2)
         self.assert_no_domain_processing()
 
+    def test_provider_payload_is_ignored_before_fulfilment(self) -> None:
+        response = self.post_payload(
+            self.payload(payload="492a37cf-49cf-43ac-a693-dbc942ac98e2"),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.apply.call_count, 1)
+        payment = self.apply.call_args.kwargs["payment"]
+        self.assertEqual(payment.intent_id, self.intent.pk)
+        self.assertEqual(payment.transaction_id, _TRANSACTION_ID)
+        self.logger.warning.assert_not_called()
+
     def test_unknown_mismatch_and_unsupported_callbacks_log_only_allowlist(
         self,
     ) -> None:


### PR DESCRIPTION
## Review Brief

### Goal

Accept the production Platega callback shape observed during a confirmed test payment so the existing fulfilment path can run.

### Observable behavior

- The existing five callback fields remain required and validated exactly as before.
- An optional provider echo field named `payload` is accepted and ignored before the domain DTO.
- Callbacks without `payload` remain valid; other unknown fields remain safe acknowledgements without fulfilment.
- The amount rule remains only `received >= saved` with no rounding or precision restriction.

### Non-goals

- No payload-value validation, polling/status GET, retry changes, manual fulfilment, callback replay, notification refactor, commission change, model, migration, settings, or bot work.

### Verification

- RED: production-shaped callback returned 200 but invoked the validator zero times.
- GREEN: production-shaped callback reaches the real validator and existing apply boundary.
- Callback view module: 22 passed.
- Full backend suite: 595 passed on the fresh rerun.
- The unrelated Crypto SQLite concurrency test that failed once passed in isolation.
- Compose config, migration check, and diff checks pass.

### Risk and deploy impact

No migration or environment change. The already-confirmed test transaction will require an explicit callback replay after this release because its original callback was acknowledged with 200.
