### PR TITLE
fix(vds): use mtprotokeys.com in proxy links

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -211,7 +211,7 @@ referrer.
   "servers": [
     {
       "location": "🇳🇱 Нидерланды",
-      "proxy_link": "tg://proxy?server=space.beatvault.ru&port=443&secret=ee..."
+      "proxy_link": "tg://proxy?server=space.mtprotokeys.com&port=443&secret=ee..."
     }
   ]
 }

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -43,7 +43,7 @@
 |------|-----|----------|
 | `hosting` | FK → Hosting? | Хостинг-провайдер сервера. Nullable для постепенного заполнения существующих записей. |
 | `expired_at` | DateField? | Дата, до которой оплачен конкретный VDS-инстанс |
-| `name` | str (unique) | DNS-субдомен сервера в хосте proxy-URL (`{name}.beatvault.ru`), напр. `kz`, `nl` |
+| `name` | str (unique) | DNS-субдомен сервера в хосте proxy-URL (`{name}.mtprotokeys.com`), напр. `kz`, `nl` |
 | `number` | SmallInt (unique) | Порядковый номер. Задаёт порядок отображения серверов (`Meta.ordering = ["number"]`), в т.ч. порядок кнопок в «Мои серверы». Управляется через админку. |
 | `ip_address` | str (unique) | Внешний IP |
 | `internal_ip_address` | str | IP в Docker-сети |
@@ -89,7 +89,7 @@
 **Менеджер:** `expired_today()` — ключи, которые истекли на сегодня.
 
 **Методы:**
-- `get_proxy_link(*, server_name)` — единственный генератор ссылки: `tg://proxy?server={server_name}.beatvault.ru&port=443&secret={secret}`. Хост зависит от имени конкретного сервера, секрет одинаков на всём флоте.
+- `get_proxy_link(*, server_name)` — единственный генератор ссылки: `tg://proxy?server={server_name}.mtprotokeys.com&port=443&secret={secret}`. Хост зависит от имени конкретного сервера, секрет одинаков на всём флоте.
 - `get_secret_token()` — `ee{token}{hex(settings.TLS_DOMAIN)}`. Домен маскировки FakeTLS берётся из `settings.TLS_DOMAIN` (одинаков на всех VDS), а не из поля модели.
 
 ---

--- a/docs/apps/VDS.md
+++ b/docs/apps/VDS.md
@@ -11,7 +11,7 @@
 ## Ключевые модели
 
 - **Hosting** — справочник хостинг-провайдеров. Хранит название и ссылку на сайт/панель хостинга; один `Hosting` связан со многими `VDSInstance`.
-- **VDSInstance** — прокси-сервер. Хранит ссылку на `Hosting`, IP-адреса, порт, `is_keys_available`, `is_healthy`, `location`, а также `expired_at` — дату, до которой оплачен конкретный инстанс. `name` — DNS-субдомен сервера в хосте proxy-URL (`{name}.beatvault.ru`). Менеджер — `ActiveQuerySet` (`.active()`); выбора «наименее нагруженного» сервера больше нет.
+- **VDSInstance** — прокси-сервер. Хранит ссылку на `Hosting`, IP-адреса, порт, `is_keys_available`, `is_healthy`, `location`, а также `expired_at` — дату, до которой оплачен конкретный инстанс. `name` — DNS-субдомен сервера в хосте proxy-URL (`{name}.mtprotokeys.com`). Менеджер — `ActiveQuerySet` (`.active()`); выбора «наименее нагруженного» сервера больше нет.
 - **MTPRotoKey** — прокси-ключ пользователя: token, дата истечения, связь с пользователем (без `vds`/`node_number`/`tls_domain`). `get_proxy_link(*, server_name)` формирует `tg://proxy` ссылку; домен маскировки — из `settings.TLS_DOMAIN`.
 
 ## Сервисы

--- a/integration_tests/test_my_servers.py
+++ b/integration_tests/test_my_servers.py
@@ -19,8 +19,8 @@ async def test_my_servers_lists_active_vds_with_proxy_links(username):
     active_count = await db.aw(db.count_active_vds)()
     assert len(result.servers) == active_count >= 1
     for server in result.servers:
-        # хост — субдомен сервера {name}.beatvault.ru, секрет из get_secret_token (TLS_DOMAIN)
-        assert ".beatvault.ru" in server.proxy_link
+        # хост — субдомен сервера {name}.mtprotokeys.com, секрет из get_secret_token (TLS_DOMAIN)
+        assert ".mtprotokeys.com" in server.proxy_link
         assert expected_secret in server.proxy_link
         assert server.location
 
@@ -76,5 +76,5 @@ async def test_my_servers_auto_activates_free_period_for_new_user(username):
     await helpers.assert_present_on_all_vds(username, present=True)
     expected_secret = await db.aw(db.key_secret_token)(username)
     for server in result.servers:
-        assert ".beatvault.ru" in server.proxy_link
+        assert ".mtprotokeys.com" in server.proxy_link
         assert expected_secret in server.proxy_link

--- a/src/apps/vds/models.py
+++ b/src/apps/vds/models.py
@@ -95,9 +95,9 @@ class MTPRotoKey(BaseDjangoModel):
 
     def get_proxy_link(self, *, server_name: str) -> str:
         """Единственный генератор proxy-ссылки: секрет валиден на всём флоте,
-        хост определяется именем конкретного сервера ({server_name}.beatvault.ru)."""
+        хост определяется именем конкретного сервера ({server_name}.mtprotokeys.com)."""
         secret = self.get_secret_token()
-        return f"tg://proxy?server={server_name}.beatvault.ru&port=443&secret={secret}"
+        return f"tg://proxy?server={server_name}.mtprotokeys.com&port=443&secret={secret}"
 
     class Meta:
         verbose_name = "MTPRoto ключ"

--- a/src/apps/vds/tests/test_admin.py
+++ b/src/apps/vds/tests/test_admin.py
@@ -36,7 +36,7 @@ class MTPRotoKeyAdminProxyLinkTest(TestCase):
 
         html = self.admin.active_proxy_link(key)
 
-        self.assertIn("nl1.beatvault.ru", html)
+        self.assertIn("nl1.mtprotokeys.com", html)
         self.assertIn(key.get_secret_token(), html)
 
     def test_dash_when_key_is_not_valid(self) -> None:

--- a/src/apps/vds/tests/test_get_my_servers_service.py
+++ b/src/apps/vds/tests/test_get_my_servers_service.py
@@ -41,7 +41,7 @@ class TestGetMyServersService(TestCase):
         self.assertIn("🇩🇪 Германия", locations)
         for server in result.servers:
             self.assertIn("tg://proxy?server=", server.proxy_link)
-            self.assertIn(".beatvault.ru", server.proxy_link)
+            self.assertIn(".mtprotokeys.com", server.proxy_link)
             domain_hex = settings.TLS_DOMAIN.encode("utf-8").hex()
             self.assertIn(f"eetesttoken{domain_hex}", server.proxy_link)
 

--- a/src/apps/vds/tests/test_models.py
+++ b/src/apps/vds/tests/test_models.py
@@ -25,7 +25,7 @@ class TestMTPRotoKeyMethods(TestCase):
         expected_secret = f"eeabc123{domain_hex}"
         self.assertEqual(
             link,
-            f"tg://proxy?server=de1.beatvault.ru&port=443&secret={expected_secret}",
+            f"tg://proxy?server=de1.mtprotokeys.com&port=443&secret={expected_secret}",
         )
 
     def test_get_secret_token_uses_settings_tls_domain(self) -> None:


### PR DESCRIPTION
## Review Brief

### Goal

Generate all newly requested MTProto proxy links with `mtprotokeys.com` as the
proxy host domain.

### Observable behavior

- `MTPRotoKey.get_proxy_link(server_name="de1")` returns a link whose host is
  `de1.mtprotokeys.com`.
- The "My servers" response and Django admin links inherit the new host through
  the existing single generator.
- Existing keys receive the new host when links are generated again; already
  sent Telegram messages are not rewritten.

### Non-goals

- No change to `TLS_DOMAIN`, FakeTLS secret construction, server names, port,
  tokens, database schema, API shape, bot flow, VPN, website, Nginx, DNS,
  certificates, health checks, or deploy configuration.
- No configurable or persisted proxy-link domain and no migration.

### Acceptance criteria

- Exact generated host is `{server_name}.mtprotokeys.com`.
- "My servers" and Django admin use the new host.
- FakeTLS secret suffix remains based on `settings.TLS_DOMAIN`.
- Targeted tests, full suite, and production Compose validation pass.
- Canonical model, VDS app, and API-contract docs describe the new host.

### Verification

- `make test ARGS="apps.vds.tests.test_models apps.vds.tests.test_get_my_servers_service apps.vds.tests.test_admin"` — 14 passed.
- `make test` — 608 passed.
- `docker compose -f docker-compose.yml config --quiet` — passed.
- `git diff --check` — passed.

### Risks

- External release dependency: the corresponding `*.mtprotokeys.com` DNS names
  must resolve to the existing proxy servers. DNS work is outside this PR.
- The pre-existing integration harness currently constructs `PaymentsClient`
  with a removed argument and fails before proxy-link assertions. This PR only
  updates the expected host strings; targeted and full project suites are green.

### Deploy impact

- Application-only behavior change; no migration or configuration change.
- Deployment is not included in this PR and requires a separate explicit
  authorization after merge.
