### PR TITLE
fix: use mtprotokeys.com across bot and VPN

### DIFF
--- a/bot/src/messages.py
+++ b/bot/src/messages.py
@@ -1,10 +1,10 @@
 from src.enums import FreeAvailable
 
-SITE_URL = "https://mtprotokeys.ru"
+SITE_URL = "https://mtprotokeys.com"
 SUPPORT_URL = "https://t.me/mtprotokeys_support"
-VPN_SETUP_URL = "https://mtprotokeys.ru/vpn/"
-TERMS_URL = "https://mtprotokeys.ru/terms"
-PRIVACY_URL = "https://mtprotokeys.ru/privacy"
+VPN_SETUP_URL = "https://mtprotokeys.com/vpn/"
+TERMS_URL = "https://mtprotokeys.com/terms"
+PRIVACY_URL = "https://mtprotokeys.com/privacy"
 
 PRODUCT_MENU_TEXT = "Выберите продукт"
 

--- a/bot/tests/test_handlers.py
+++ b/bot/tests/test_handlers.py
@@ -70,7 +70,7 @@ APPROVED_MTPROXY_PAYMENT_TEXT = """💳 <b>Оплата подписки</b>
 
 После оплаты новый ключ будет выдан автоматически. Если у вас уже есть активный ключ, подписка продлится на 30 дней.
 
-<i>Оплачивая подписку, вы принимаете <a href="https://mtprotokeys.ru/terms">Условия использования</a> и <a href="https://mtprotokeys.ru/privacy">Политику конфиденциальности</a>.</i>
+<i>Оплачивая подписку, вы принимаете <a href="https://mtprotokeys.com/terms">Условия использования</a> и <a href="https://mtprotokeys.com/privacy">Политику конфиденциальности</a>.</i>
 
 👇 <b>Выберите способ оплаты:</b>"""
 
@@ -81,7 +81,7 @@ APPROVED_VPN_PAYMENT_TEXT = """💳 <b>Оплата подписки</b>
 
 После оплаты VPN-подписка будет активирована автоматически. При продлении ваша постоянная subscription-ссылка не изменится.
 
-<i>Оплачивая подписку, вы принимаете <a href="https://mtprotokeys.ru/terms">Условия использования</a> и <a href="https://mtprotokeys.ru/privacy">Политику конфиденциальности</a>.</i>
+<i>Оплачивая подписку, вы принимаете <a href="https://mtprotokeys.com/terms">Условия использования</a> и <a href="https://mtprotokeys.com/privacy">Политику конфиденциальности</a>.</i>
 
 👇 <b>Выберите способ оплаты:</b>"""
 
@@ -92,7 +92,7 @@ APPROVED_GIFT_PAYMENT_TEXT = """💳 <b>Оплата подарка</b>
 
 После оплаты вы получите одноразовый код, который можно переслать другому человеку. Код создаст новый ключ или продлит действующий на 30 дней.
 
-<i>Оплачивая сертификат, вы принимаете <a href="https://mtprotokeys.ru/terms">Условия использования</a> и <a href="https://mtprotokeys.ru/privacy">Политику конфиденциальности</a>.</i>
+<i>Оплачивая сертификат, вы принимаете <a href="https://mtprotokeys.com/terms">Условия использования</a> и <a href="https://mtprotokeys.com/privacy">Политику конфиденциальности</a>.</i>
 
 👇 <b>Выберите способ оплаты:</b>"""
 
@@ -627,6 +627,7 @@ def test_mtproxy_menu_links_to_site_and_support():
     urls = [btn.url for row in markup.inline_keyboard for btn in row if btn.url]
     assert SUPPORT_URL == "https://t.me/mtprotokeys_support"
     assert "https://t.me/mtprotokeys_support" in urls
+    assert "https://mtprotokeys.com" in urls
     assert set(urls) >= {SITE_URL, SUPPORT_URL}
 
 
@@ -634,6 +635,10 @@ def test_info_keyboard_links_to_legal_docs_and_drops_offer():
     markup = keyboards.info()
 
     urls = [btn.url for row in markup.inline_keyboard for btn in row if btn.url]
+    assert set(urls) >= {
+        "https://mtprotokeys.com/terms",
+        "https://mtprotokeys.com/privacy",
+    }
     assert TERMS_URL in urls
     assert PRIVACY_URL in urls
     assert not any("drive.google.com" in url for url in urls)
@@ -998,7 +1003,7 @@ async def test_vpn_product_menu_uses_approved_copy_and_actions():
     ] == [
         [("💳 Купить VPN", "vpn", None, "success")],
         [("🔑 Моя подписка", "vpn_subscription", None, "primary")],
-        [("📖 Как настроить", None, "https://mtprotokeys.ru/vpn/", None)],
+        [("📖 Как настроить", None, "https://mtprotokeys.com/vpn/", None)],
         [("💬 Поддержка", None, "https://t.me/mtprotokeys_support", None)],
         [("🔙 Назад", "show_start_screen", None, None)],
     ]

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -396,7 +396,7 @@ signature или секреты.
 ### GET /api/v1/vpn/subscriptions/<token>/
 
 Публичный endpoint. Успешный ответ имеет `200 OK`, `Content-Type: text/plain` и
-`profile-title: mtprotokeys.ru`; новый заголовок не изменяет существующие
+`profile-title: mtprotokeys.com`; новый заголовок не изменяет существующие
 subscription URL или Base64 payload.
 
 ### POST /api/v1/vpn/payments/buy/

--- a/src/apps/vpn/api/v1/views/subscription_views.py
+++ b/src/apps/vpn/api/v1/views/subscription_views.py
@@ -18,5 +18,5 @@ class VPNSubscriptionView(APIView):
         response = HttpResponse(subscription, content_type="text/plain")
         response["Cache-Control"] = "private, no-store"
         response["X-Content-Type-Options"] = "nosniff"
-        response["profile-title"] = "mtprotokeys.ru"
+        response["profile-title"] = "mtprotokeys.com"
         return response

--- a/src/apps/vpn/tests/test_subscription_view.py
+++ b/src/apps/vpn/tests/test_subscription_view.py
@@ -35,7 +35,7 @@ class TestVPNSubscriptionView(APITestCase):
         self.assertEqual(response["Content-Type"], "text/plain")
         self.assertEqual(response["Cache-Control"], "private, no-store")
         self.assertEqual(response["X-Content-Type-Options"], "nosniff")
-        self.assertEqual(response["profile-title"], "mtprotokeys.ru")
+        self.assertEqual(response["profile-title"], "mtprotokeys.com")
         self.assertEqual(
             b64decode(response.content).decode("utf-8").splitlines(),
             [
@@ -67,7 +67,7 @@ class TestVPNSubscriptionView(APITestCase):
         self.assertEqual(response["Content-Type"], "text/plain")
         self.assertEqual(response["Cache-Control"], "private, no-store")
         self.assertEqual(response["X-Content-Type-Options"], "nosniff")
-        self.assertEqual(response["profile-title"], "mtprotokeys.ru")
+        self.assertEqual(response["profile-title"], "mtprotokeys.com")
         self.assertEqual(
             b64decode(response.content).decode("utf-8").splitlines(),
             [


### PR DESCRIPTION
## Review Brief

### Цель

Перевести пользовательские ссылки Telegram-бота и VPN `profile-title` с
`mtprotokeys.ru` на `mtprotokeys.com`.

### Наблюдаемое поведение

- кнопки сайта, настройки VPN, условий и политики открывают те же пути `.com`;
- юридические ссылки в сообщениях используют `.com`;
- VPN subscription response возвращает `profile-title: mtprotokeys.com`.

### Non-goals

- пути, тексты кнопок, callback-и и support URL не меняются;
- домен не выносится в настройки; соседний код не рефакторится;
- миграций и новых зависимостей нет.

### Критерии приёмки

- `mtprotokeys.ru` отсутствует в отслеживаемых файлах;
- URL бота и VPN `profile-title` используют `mtprotokeys.com`;
- тесты и production Compose config проходят.

### Проверки

- `make test` — 608 passed;
- `bot/.venv/bin/pytest bot/tests -q` — 138 passed;
- `docker compose -f docker-compose.yml config --quiet` — exit 0;
- `ruff check bot/src/messages.py src/apps/vpn/api/v1/views/subscription_views.py` — passed;
- `git diff --check` и поиск `mtprotokeys.ru` в tracked-файлах — passed.

Полный Ruff затронутых тестовых файлов сохраняет четыре существующих lint
замечания из `main`; новых lint-регрессий нет.

### Риски и deploy impact

Риск низкий: меняются только строковые URL и HTTP header, тестовые ожидания и
контрактная документация. После merge требуется обычный deploy backend и bot;
миграций нет.
