### PR TITLE
fix(vds): make expired key cleanup resilient

### DIFF
--- a/docs/apps/VDS.md
+++ b/docs/apps/VDS.md
@@ -24,7 +24,10 @@
 - **GetMyServersService** — генерирует `tg://proxy` ссылки на лету для каждого активного VDS. Если активного ключа нет, а бесплатный период не использован, активирует его через инъектированный `FirstFreeLinkService` и сразу возвращает серверы; если период израсходован — `KeyDoesNotExist`.
 - **VDSHealthCheckInfraService** — проверяет доступность сервера GET-запросом.
 - **RemoveUserKeyInfraService** / **RemoveKeysFromVdsInstanceInfraService** / **RemoveDeadKeysFromVdsInfraService** — удаление ключей с VDS.
-- **RemoveExpiredKeysDailyService** — дневное удаление истёкших ключей.
+- **RemoveExpiredKeysDailyService** — дневное удаление истёкших ключей. Недоступность
+  одного активного VDS (`VDSNotAvailable`) изолируется: этот сервер помечается
+  нездоровым, остальные активные VDS всё равно обрабатываются, после чего
+  сохраняется существующая деактивация ключей в БД и уведомление пользователя.
 
 ## Celery-задачи
 
@@ -36,7 +39,11 @@
 - **migrate_vds_keys_task** — досылка всех активных ключей на остальные серверы (админ-экшен)
 - **sync_keys_to_vds_task** — синхронизирует все активные ключи БД на конкретный сервер
 - **remove_dead_keys_from_vds_task** / **remove_key_from_another_vds_instances_task** — удаление ключей с серверов
-- **check_vds_health_task** — каждые 5 минут проверяет нездоровые (`is_healthy=False`) серверы; при восстановлении: выставляет `is_healthy=True`, запускает `sync_keys_to_vds_task`
+- **check_vds_health_task** — каждые 5 минут проверяет нездоровые (`is_healthy=False`)
+  серверы; после успешного probe сначала синхронно удаляет с VDS известные БД
+  истёкшие ключи, затем выставляет `is_healthy=True` и запускает
+  `sync_keys_to_vds_task`. При `VDSNotAvailable` во время удаления сервер остаётся
+  нездоровым, его sync не запускается, а обработка остальных нездоровых VDS продолжается.
 - **broadcast_proxy_links_task** — массовая рассылка
 
 ## Механизм отказоустойчивости доставки
@@ -55,7 +62,8 @@ _handle_replication_failure
       ▼
 check_vds_health_task (каждые 5 мин)
   → VDSHealthCheckInfraService: GET internal_url
-  → восстановлен → is_healthy = True, sync_keys_to_vds_task (бэкфилл)
+  → восстановлен → удалить известные БД истёкшие ключи
+  → is_healthy = True → sync_keys_to_vds_task (бэкфилл)
 ```
 
 ## Зависимости

--- a/docs/apps/VDS.md
+++ b/docs/apps/VDS.md
@@ -40,8 +40,9 @@
 - **sync_keys_to_vds_task** — синхронизирует все активные ключи БД на конкретный сервер
 - **remove_dead_keys_from_vds_task** / **remove_key_from_another_vds_instances_task** — удаление ключей с серверов
 - **check_vds_health_task** — каждые 5 минут проверяет нездоровые (`is_healthy=False`)
-  серверы; после успешного probe сначала синхронно удаляет с VDS известные БД
-  истёкшие ключи, затем выставляет `is_healthy=True` и запускает
+  серверы; после успешного probe ожидает завершения ежедневной деактивации, если
+  в БД ещё есть активные истёкшие ключи. Затем синхронно удаляет с VDS известные
+  БД истёкшие ключи, выставляет `is_healthy=True` и запускает
   `sync_keys_to_vds_task`. При `VDSNotAvailable` во время удаления сервер остаётся
   нездоровым, его sync не запускается, а обработка остальных нездоровых VDS продолжается.
 - **broadcast_proxy_links_task** — массовая рассылка
@@ -62,6 +63,7 @@ _handle_replication_failure
       ▼
 check_vds_health_task (каждые 5 мин)
   → VDSHealthCheckInfraService: GET internal_url
+  → active expired keys ожидают DB-деактивацию → оставаться unhealthy
   → восстановлен → удалить известные БД истёкшие ключи
   → is_healthy = True → sync_keys_to_vds_task (бэкфилл)
 ```

--- a/src/apps/vds/services/remove_expired_keys_daily_service.py
+++ b/src/apps/vds/services/remove_expired_keys_daily_service.py
@@ -10,6 +10,7 @@ from apps.core.exceptions import BaseServiceError
 from apps.core.telegram.error_logger import log_service_error
 from apps.core.telegram.transport import send_telegram_message
 from apps.notifications.selectors import get_template
+from apps.vds.exceptions import VDSNotAvailable
 from apps.vds.selectors import get_all_active_vds_instances, get_keys_expired_up_to_date
 from apps.vds.services.remove_key_infra_service import get_remove_user_key_infra_service
 
@@ -25,7 +26,11 @@ class RemoveExpiredKeysDailyService:
 
         service = get_remove_user_key_infra_service()
         for server in get_all_active_vds_instances():
-            service(server=server, keys=queryset)
+            try:
+                service(server=server, keys=queryset)
+            except VDSNotAvailable:
+                server.is_healthy = False
+                server.save(update_fields=["is_healthy"])
 
         queryset.update(is_active=False, was_deleted=True)
 

--- a/src/apps/vds/tasks.py
+++ b/src/apps/vds/tasks.py
@@ -102,12 +102,19 @@ def sync_keys_to_vds_task(instance_id: int) -> None:
 
 @shared_task
 def check_vds_health_task() -> None:
+    from apps.vds.exceptions import VDSNotAvailable
     from apps.vds.selectors import get_unhealthy_vds_instances
+    from apps.vds.services import get_remove_dead_keys_from_vds_infra_service
     from apps.vds.services.vds_health_check_infra_service import get_vds_health_check_infra_service
 
     service = get_vds_health_check_infra_service()
+    remove_dead_keys = get_remove_dead_keys_from_vds_infra_service()
     for server in get_unhealthy_vds_instances():
         if service(instance_id=server.pk):
+            try:
+                remove_dead_keys(instance_id=server.pk)
+            except VDSNotAvailable:
+                continue
             server.is_healthy = True
             server.save(update_fields=["is_healthy"])
             sync_keys_to_vds_task.delay(instance_id=server.pk)

--- a/src/apps/vds/tasks.py
+++ b/src/apps/vds/tasks.py
@@ -102,8 +102,10 @@ def sync_keys_to_vds_task(instance_id: int) -> None:
 
 @shared_task
 def check_vds_health_task() -> None:
+    from django.utils import timezone
+
     from apps.vds.exceptions import VDSNotAvailable
-    from apps.vds.selectors import get_unhealthy_vds_instances
+    from apps.vds.selectors import get_keys_expired_up_to_date, get_unhealthy_vds_instances
     from apps.vds.services import get_remove_dead_keys_from_vds_infra_service
     from apps.vds.services.vds_health_check_infra_service import get_vds_health_check_infra_service
 
@@ -111,6 +113,8 @@ def check_vds_health_task() -> None:
     remove_dead_keys = get_remove_dead_keys_from_vds_infra_service()
     for server in get_unhealthy_vds_instances():
         if service(instance_id=server.pk):
+            if get_keys_expired_up_to_date(date=timezone.now().date()).exists():
+                continue
             try:
                 remove_dead_keys(instance_id=server.pk)
             except VDSNotAvailable:

--- a/src/apps/vds/tests/test_services/test_remove_expired_keys_daily_service.py
+++ b/src/apps/vds/tests/test_services/test_remove_expired_keys_daily_service.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from apps.users.tests.factories import SystemUserFactory
+from apps.vds.exceptions import VDSNotAvailable
 from apps.vds.services import get_remove_expired_keys_daily_service
 from apps.vds.tests.factories import MTPRotoKeyFactory, VDSInstanceFactory
 
@@ -36,6 +37,43 @@ class TestRemoveExpiredKeysDailyService(TestCase):
         get_remove_expired_keys_daily_service()()
         self.assertEqual(infra_service.call_count, 0)
 
+    @mock.patch("apps.vds.services.remove_expired_keys_daily_service.time")
+    @mock.patch("apps.vds.services.remove_expired_keys_daily_service.get_template")
+    @mock.patch("apps.vds.services.remove_expired_keys_daily_service.send_telegram_message")
+    @mock.patch("apps.vds.services.remove_key_infra_service.RemoveUserKeyInfraService.__call__")
+    def test_unavailable_vds_does_not_abort_cleanup(
+        self,
+        remove_user_key,
+        mock_send,
+        mock_get_template,
+        _time,
+    ) -> None:
+        second_server = VDSInstanceFactory()
+        mock_get_template.return_value.render.return_value = mock.Mock(text="deactivated", markup=None)
+        self.key.expired_date = timezone.now()
+        self.key.save()
+
+        def remove_from_server(*, server, keys) -> None:
+            if server.pk == self.server.pk:
+                raise VDSNotAvailable(telegram_id=self.user.username)
+
+        remove_user_key.side_effect = remove_from_server
+
+        get_remove_expired_keys_daily_service()()
+
+        self.assertEqual(
+            [call.kwargs["server"].pk for call in remove_user_key.call_args_list],
+            [self.server.pk, second_server.pk],
+        )
+        self.server.refresh_from_db()
+        second_server.refresh_from_db()
+        self.key.refresh_from_db()
+        self.assertFalse(self.server.is_healthy)
+        self.assertTrue(second_server.is_healthy)
+        self.assertFalse(self.key.is_active)
+        self.assertTrue(self.key.was_deleted)
+        mock_send.assert_called_once_with(chat_id=int(self.user.username), text="deactivated", markup=None)
+
     @responses.activate
     @mock.patch("apps.vds.services.remove_expired_keys_daily_service.time")
     @mock.patch("apps.vds.services.remove_expired_keys_daily_service.get_template")
@@ -52,7 +90,9 @@ class TestRemoveExpiredKeysDailyService(TestCase):
         self.assertEqual(mock_send.call_count, 1)
         self.assertEqual(mock_send.call_args.kwargs["chat_id"], int(self.user.username))
 
+        self.server.refresh_from_db()
         self.key.refresh_from_db()
+        self.assertTrue(self.server.is_healthy)
         self.assertFalse(self.key.is_active)
         self.assertTrue(self.key.was_deleted)
 

--- a/src/apps/vds/tests/test_tasks/test_check_vds_health_task.py
+++ b/src/apps/vds/tests/test_tasks/test_check_vds_health_task.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from apps.vds.exceptions import VDSNotAvailable
 from apps.vds.tasks import check_vds_health_task
 from apps.vds.tests.factories import VDSInstanceFactory
 
@@ -69,3 +70,76 @@ class TestCheckVdsHealthTask(TestCase):
         called_ids = {c.kwargs["instance_id"] for c in mock_sync.delay.call_args_list}
         self.assertIn(self.unhealthy_server.pk, called_ids)
         self.assertIn(second_unhealthy.pk, called_ids)
+
+    @patch("apps.vds.tasks.sync_keys_to_vds_task")
+    @patch("apps.vds.services.get_remove_dead_keys_from_vds_infra_service")
+    @patch(
+        "apps.vds.services.vds_health_check_infra_service."
+        "get_vds_health_check_infra_service"
+    )
+    def test_cleanup_precedes_recovery_and_unavailable_vds_isolated(
+        self,
+        mock_health_check_factory,
+        mock_cleanup_factory,
+        mock_sync,
+    ) -> None:
+        recovered_server = VDSInstanceFactory(is_healthy=False)
+        cleanup_failed_server = VDSInstanceFactory(is_healthy=False)
+        second_recovered_server = VDSInstanceFactory(is_healthy=False)
+        servers = {
+            self.unhealthy_server.pk: self.unhealthy_server,
+            recovered_server.pk: recovered_server,
+            cleanup_failed_server.pk: cleanup_failed_server,
+            second_recovered_server.pk: second_recovered_server,
+        }
+        recovery_events = []
+
+        mock_health_check_factory.return_value.side_effect = (
+            lambda *, instance_id: instance_id != self.unhealthy_server.pk
+        )
+
+        def remove_dead_keys(*, instance_id: int) -> None:
+            if instance_id == cleanup_failed_server.pk:
+                raise VDSNotAvailable(telegram_id=[])
+
+            server = servers[instance_id]
+            server.refresh_from_db()
+            self.assertFalse(server.is_healthy)
+            recovery_events.append(("cleanup", instance_id))
+
+        def queue_sync(*, instance_id: int) -> None:
+            server = servers[instance_id]
+            server.refresh_from_db()
+            self.assertTrue(server.is_healthy)
+            recovery_events.append(("sync", instance_id))
+
+        mock_cleanup_factory.return_value.side_effect = remove_dead_keys
+        mock_sync.delay.side_effect = queue_sync
+
+        check_vds_health_task()
+
+        self.unhealthy_server.refresh_from_db()
+        recovered_server.refresh_from_db()
+        cleanup_failed_server.refresh_from_db()
+        second_recovered_server.refresh_from_db()
+        self.assertFalse(self.unhealthy_server.is_healthy)
+        self.assertTrue(recovered_server.is_healthy)
+        self.assertFalse(cleanup_failed_server.is_healthy)
+        self.assertTrue(second_recovered_server.is_healthy)
+        self.assertEqual(
+            [call.kwargs["instance_id"] for call in mock_cleanup_factory.return_value.call_args_list],
+            [recovered_server.pk, cleanup_failed_server.pk, second_recovered_server.pk],
+        )
+        self.assertEqual(
+            [call.kwargs["instance_id"] for call in mock_sync.delay.call_args_list],
+            [recovered_server.pk, second_recovered_server.pk],
+        )
+        self.assertEqual(
+            recovery_events,
+            [
+                ("cleanup", recovered_server.pk),
+                ("sync", recovered_server.pk),
+                ("cleanup", second_recovered_server.pk),
+                ("sync", second_recovered_server.pk),
+            ],
+        )

--- a/src/apps/vds/tests/test_tasks/test_check_vds_health_task.py
+++ b/src/apps/vds/tests/test_tasks/test_check_vds_health_task.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.utils import timezone
 
 from apps.vds.exceptions import VDSNotAvailable
 from apps.vds.tasks import check_vds_health_task
-from apps.vds.tests.factories import VDSInstanceFactory
+from apps.vds.tests.factories import MTPRotoKeyFactory, VDSInstanceFactory
 
 
 class TestCheckVdsHealthTask(TestCase):
@@ -143,3 +144,62 @@ class TestCheckVdsHealthTask(TestCase):
                 ("sync", second_recovered_server.pk),
             ],
         )
+
+    @patch("apps.vds.tasks.sync_keys_to_vds_task")
+    @patch("apps.vds.services.get_remove_dead_keys_from_vds_infra_service")
+    @patch(
+        "apps.vds.services.vds_health_check_infra_service."
+        "get_vds_health_check_infra_service"
+    )
+    def test_waits_for_pending_daily_deactivation_before_recovery(
+        self,
+        mock_health_check_factory,
+        mock_cleanup_factory,
+        mock_sync,
+    ) -> None:
+        pending_key = MTPRotoKeyFactory(
+            expired_date=timezone.now(),
+            is_active=True,
+            was_deleted=False,
+        )
+        recovery_events = []
+        mock_health_check_factory.return_value.return_value = True
+
+        def remove_dead_keys(*, instance_id: int) -> None:
+            self.assertEqual(instance_id, self.unhealthy_server.pk)
+            self.unhealthy_server.refresh_from_db()
+            self.assertFalse(self.unhealthy_server.is_healthy)
+            recovery_events.append("cleanup")
+
+        def queue_sync(*, instance_id: int) -> None:
+            self.assertEqual(instance_id, self.unhealthy_server.pk)
+            self.unhealthy_server.refresh_from_db()
+            self.assertTrue(self.unhealthy_server.is_healthy)
+            recovery_events.append("sync")
+
+        mock_cleanup_factory.return_value.side_effect = remove_dead_keys
+        mock_sync.delay.side_effect = queue_sync
+
+        check_vds_health_task()
+
+        self.unhealthy_server.refresh_from_db()
+        pending_key.refresh_from_db()
+        self.assertFalse(self.unhealthy_server.is_healthy)
+        self.assertTrue(pending_key.is_active)
+        self.assertFalse(pending_key.was_deleted)
+        mock_cleanup_factory.return_value.assert_not_called()
+        mock_sync.delay.assert_not_called()
+
+        pending_key.is_active = False
+        pending_key.was_deleted = True
+        pending_key.save(update_fields=["is_active", "was_deleted"])
+
+        check_vds_health_task()
+
+        self.unhealthy_server.refresh_from_db()
+        self.assertTrue(self.unhealthy_server.is_healthy)
+        mock_cleanup_factory.return_value.assert_called_once_with(
+            instance_id=self.unhealthy_server.pk
+        )
+        mock_sync.delay.assert_called_once_with(instance_id=self.unhealthy_server.pk)
+        self.assertEqual(recovery_events, ["cleanup", "sync"])


### PR DESCRIPTION
## Review Brief

### Goal

Keep daily MTProto expired-key cleanup timely when one active VDS is
unavailable, and reconcile that mirror before it returns to healthy service.

### Observable behavior

- A per-VDS `VDSNotAvailable` during daily cleanup marks only that VDS
  unhealthy and does not stop attempts against the remaining active VDS
  instances.
- After the fleet loop, the existing DB deactivation and
  `link_deactivated` user notification still run.
- When an unhealthy VDS passes the existing recovery probe, dead expired keys
  are removed synchronously while it is still unhealthy. Recovery waits if
  expired active keys are still awaiting the daily task's DB-deactivation
  phase. Only successful cleanup permits `is_healthy=True` and the existing
  active-key sync.
- Cleanup `VDSNotAvailable` leaves that VDS unhealthy without sync and does not
  stop recovery processing for other unhealthy VDS instances.
- Other unexpected exceptions still propagate.

### Non-goals

- No changes to `log_infra_error`, decorators, messages, or notification
  templates.
- No health endpoint, VDS-instance repository change, probe-semantics change,
  or all-fleet health monitoring.
- No models, migrations, per-server delivery state, retries, schedules, API
  contracts, settings, dependencies, or expiry-rule changes.

### Acceptance criteria

- Failure on the first of two active VDS instances still attempts the second,
  marks only the failed VDS unhealthy, deactivates the expired key in DB, and
  sends the existing user notification.
- Successful daily cleanup preserves healthy state.
- A failed recovery probe invokes neither cleanup nor sync.
- Successful recovery orders cleanup → healthy save → active-key sync.
- A recovery probe interleaved before daily DB deactivation leaves the VDS
  unhealthy and unsynced; a later run performs cleanup before recovery.
- Recovery cleanup failure keeps that server unhealthy/no-sync while later
  unhealthy servers still progress.

### Verification

- `make test` — 618 tests, OK; Django system check: 0 issues.
- Focused changed modules — 11 tests, OK, with separate RED/GREEN evidence for
  both behavior changes.
- `docker compose -f docker-compose.yml config --quiet` — exit 0.
- `git diff --check` — exit 0.
- Independent batch review — approved after one AC-002 test-coverage fix.
- Product acceptance — accepted; BR-001..BR-005 and AC-001..AC-005 passed.

### Risks and deploy impact

- A down VDS can retain expired keys until its existing recovery cycle reaches
  successful dead-key cleanup; it remains marked unhealthy until then.
- Backend-only code and documentation change. No migration or configuration
  change. Normal whole-stack release is sufficient after separately authorized
  merge and deploy gates.
